### PR TITLE
1 lead could not be posted because must specify api key

### DIFF
--- a/State Revenue Report.csv
+++ b/State Revenue Report.csv
@@ -1,6 +1,6 @@
 Company US State,Total Companies,Total Revenue,Median Revenue,Company with Most Revenue
 New York,10,45184203.84,3035151.79,Twimm
-California,21,100157324.31,4674023.84,Trilia
+California,20,97379712.74,4751635.6,Trilia
 Minnesota,1,6069278.62,6069278.62,Flipstorm
 Delaware,1,3653283.58,3653283.58,Teklist
 New Mexico,1,1587892.9,1587892.9,Edgeblab

--- a/import.py
+++ b/import.py
@@ -58,22 +58,14 @@ with open(source_file, 'r') as csvfile:
             print(f"invalid contact! {contact.to_dict()}")
 
 ####  Removing Leads grouped with Contacts that have invalid data. ### 
-for error in errors:
-    for lead in leads:
-        if lead.name == error.name:
-            leads.remove(lead)
+Lead.remove_leads_with_errors(leads, errors)
 
 ###  Importing Leads grouped with Contacts provided the associated contact in a group didn't have errors. ### 
 # Set API Key
 api_key = os.getenv("CLOSE_API_KEY")
 api = Client(api_key)
 
-for lead in leads:
-    try:
-        response = api.post('lead', data=lead.to_dict())
-        print(response)
-    except Exception as e:
-        print(f"{lead}: Lead could not be posted because {str(e)}")
+Lead.post_leads(leads, api, errors)
 
 ### Generating CSV with State Revenue report ### 
 # Group the Leads by US State
@@ -101,7 +93,8 @@ with open('State Revenue Report.csv', 'w', newline='') as output_file:
         })
 
 
-for lead in leads:
-    print(lead.to_dict())
-count = len(leads)
-print(f"Job Done!! total leads imported: {count}")
+# for lead in leads:
+#     print(lead.to_dict())
+lead_count = len(leads)
+error_count = len(errors)
+print(f"Job Done!! total leads imported: {lead_count} errors: {error_count}")

--- a/lead.py
+++ b/lead.py
@@ -56,6 +56,22 @@ class Lead:
             if lead.name == row["Company"]:
                 lead.contacts.append(contact)
 
+    def post_leads(leads, api, errors):
+        for lead in leads:
+            try:
+                response = api.post('lead', data=lead.to_dict())
+                print(f"API response: {response}")
+            except Exception as e:
+                errors.append(lead)
+                print(f"{lead.name} Lead could not be posted because: {str(e)}")
+        Lead.remove_leads_with_errors(leads, errors)
+
+    def remove_leads_with_errors(leads, errors):
+        for error in errors:
+            for lead in leads:
+                if lead.name == error.name:
+                    leads.remove(lead)
+
     def missing_state(lead):
         return lead.custom_fields[Lead.FIELDS["company_us_state"]] in [None,'']
     

--- a/tests/test_lead.py
+++ b/tests/test_lead.py
@@ -1,6 +1,5 @@
 import unittest
 from closeio_api import Client
-# from unittest.mock import MagicMock, mock_open, patch
 import sys
 import io
 sys.path.append('.')

--- a/tests/test_lead.py
+++ b/tests/test_lead.py
@@ -1,0 +1,57 @@
+import unittest
+from closeio_api import Client
+# from unittest.mock import MagicMock, mock_open, patch
+import sys
+import io
+sys.path.append('.')
+from lead import Lead
+
+class TestLead(unittest.TestCase):
+    def setUp(self):
+        self.lead  = Lead("Close test", {
+            Lead.FIELDS["company_founded"] : "01.01.2011",
+            Lead.FIELDS["company_revenue"] : "$1,000,000,000.01",
+            Lead.FIELDS["company_us_state"] : "California"
+        })
+        self.leads = [Lead("Close test", {
+            Lead.FIELDS["company_founded"] : "01.01.2011",
+            Lead.FIELDS["company_revenue"] : "$1,000,000,000.01",
+            Lead.FIELDS["company_us_state"] : "California"
+            }),
+            Lead("Close test2", {
+            Lead.FIELDS["company_founded"] : "01.01.2011",
+            Lead.FIELDS["company_revenue"] : "$1,000,000,000.01",
+            Lead.FIELDS["company_us_state"] : "California"
+            })]
+
+    def test_lead_name(self):
+        self.assertEqual(self.lead.name, "Close test")
+
+    def test_leads_count(self):
+        self.assertEqual(len(self.leads), 2)
+
+    def test_leads_post_no_api_key_error(self):
+        api_key = None
+        close_api = Client(api_key)
+        captured_output = io.StringIO()
+        # save stdout to a variable
+        sys.stdout = captured_output
+
+        Lead.post_leads(self.leads, close_api, errors=[])
+
+        # restore stdout to ensure each test is isolated
+        sys.stdout = sys.__stdout__
+        
+        expected_output = f"{self.lead.name} Lead could not be posted because: Must specify api_key."
+        self.assertIn(expected_output, captured_output.getvalue())
+
+    def test_leads_post_tracks_errors(self):
+        errors=[]
+        api_key = None
+        close_api = Client(api_key)
+        Lead.post_leads(self.leads, close_api, errors)
+        self.assertEqual(len(self.leads), 0)
+        self.assertEqual(len(errors), 2)        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes bug related to lead import not removing leads that had API failures. 